### PR TITLE
README: Expand note for new composite version of the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@
 
 GitHub Action to render file based on template and passed variables.
 
-> [!NOTE]
->
-> This action is available in two versions:
->
-> - **Docker** (`chuhlomin/render-template@v1`) — default, works on `ubuntu-latest` and other Linux runners with Docker support
-> - **Binary** (`chuhlomin/render-template/binary@v1`) — works on all runners, including macOS, Windows, and `ubuntu-slim`
+This action is available in two versions:
+
+- **Docker** (`chuhlomin/render-template@v1`) — default, works on `ubuntu-latest` and other Linux runners with Docker support
+- **Binary** (`chuhlomin/render-template/binary@v1`) — works on all runners, including macOS, Windows, and `ubuntu-slim`
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 
 GitHub Action to render file based on template and passed variables.
 
-> [!NOTE]  
-> This is a Docker-based action and may not work on Windows and macOS runners.
+> [!NOTE]
 >
-> If you run into Docker-related issues on your runner (e.g. `ubuntu-slim`),  
-> please use the binary version of the action instead: `chuhlomin/render-template/binary@v1`
+> This action is available in two versions:
+>
+> - **Docker** (`chuhlomin/render-template@v1`) — default, works on `ubuntu-latest` and other Linux runners with Docker support
+> - **Binary** (`chuhlomin/render-template/binary@v1`) — works on all runners, including macOS, Windows, and `ubuntu-slim`
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
 GitHub Action to render file based on template and passed variables.
 
 > [!NOTE]  
-> This is a Docker-based action and may not work on Windows and MacOS runners.
+> This is a Docker-based action and may not work on Windows and macOS runners.
+>
+> If you run into docker-related issues on your runner (e.g. `ubuntu-slim`),  
+> please use the binary version of the action instead: `chuhlomin/render-template/binary@v1`
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GitHub Action to render file based on template and passed variables.
 > [!NOTE]  
 > This is a Docker-based action and may not work on Windows and macOS runners.
 >
-> If you run into docker-related issues on your runner (e.g. `ubuntu-slim`),  
+> If you run into Docker-related issues on your runner (e.g. `ubuntu-slim`),  
 > please use the binary version of the action instead: `chuhlomin/render-template/binary@v1`
 
 ## Inputs


### PR DESCRIPTION
https://github.com/chuhlomin/render-template/commit/7caa712722660b8af713f7a389f1c74c0063b57c added a new [composite action](https://docs.github.com/en/actions/concepts/workflows-and-actions/custom-actions#types-of-actions) which uses the pre-compiled binary of the action (released in [v1.11](https://github.com/chuhlomin/render-template/releases/tag/v1.11)).

Related to https://github.com/chuhlomin/render-template/issues/18#issuecomment-4248936818.

<br>

Adding a note to the current "This is a Docker action" hint:
<img width="825" height="557" alt="image" src="https://github.com/user-attachments/assets/d0cd6116-2517-4225-b59a-b295ef56217a" />
